### PR TITLE
Adding Duolingo goal checker

### DIFF
--- a/duoling_status.py
+++ b/duoling_status.py
@@ -1,0 +1,34 @@
+import duolingo
+import time
+from datetime import datetime
+
+# log in
+lingo = duolingo.Duolingo('[your username here]', '[your password here]')
+
+# set your daily goal
+daily_goal = 50
+
+def check_goal_reached(duolingo, goal):
+
+    xp_json = duolingo.get_daily_xp_progress()
+    lessons_blob = xp_json['lessons_today']
+
+    lesson_xp = 0
+    current_date = datetime.today().date()
+
+    # duolingo's api endpoints return xp & lessons strangely
+    # xp & lessons carry over from previous days until a new
+    # lesson is completed, thus the below date validation
+
+    for lesson in lessons_blob:
+        lesson_localized_date = datetime.fromtimestamp(lesson['time']).date()
+
+        if lesson_localized_date == current_date:
+            lesson_xp += lesson['xp']
+
+    if lesson_xp > goal:
+        return True
+    else:
+        return False
+
+# print(check_goal_reached(lingo, daily_goal))


### PR DESCRIPTION
Phew.

Worst part about retrieving this data was that using pre-built modules like `requests` didn't work. Duolingo requires that I pass them authentication. I tried a whole lotta sh*t (even StackExchange after I got desperate), but eventually caved into the failing build, sketchy Duolingo API.

Anyways, it finally works. Couple minor blocks in the road, but took care of them (see comments).